### PR TITLE
peng/reorganization 2018 05 02

### DIFF
--- a/src/components/common/AppFooter.vue
+++ b/src/components/common/AppFooter.vue
@@ -5,26 +5,26 @@
     .footbot__brandmark
       img.footbot__img(src="~images/logos/cosmos-brandmark.png")
     .footbot-menu
-      .footbot-menu__title About
+      .footbot-menu__title Foundation
       .footbot-menu__items
-        router-link(:to="{ name: 'about'}").footbot-menu__item Team
+        router-link(:to="{ name: 'about'}").footbot-menu__item About
         router-link(:to="{ name: 'events'}").footbot-menu__item Events
         router-link(:to="{ name: 'assets'}").footbot-menu__item Media Assets
         a(:href="config.FUNDRAISER_URL" target="_blank").footbot-menu__item Fundraiser
     .footbot-menu
       .footbot-menu__title Learn
       .footbot-menu__items
-        router-link(:to="{ name: 'intro'}").footbot-menu__item Introduction
-        router-link(:to="{ name: 'faq'}").footbot-menu__item FAQ
+        router-link(:to="{ name: 'resources'}").footbot-menu__item Resources
+        router-link(:to="{ name: 'academy'}").footbot-menu__item Academy
         router-link(:to="{ name: 'whitepaper'}").footbot-menu__item Whitepaper
-        router-link(:to="{ name: 'validators'}").footbot-menu__item Validators
+        router-link(:to="{ name: 'faq'}").footbot-menu__item FAQ
     .footbot-menu
       .footbot-menu__title Develop
       .footbot-menu__items
-        router-link(:to="{ name: 'developers'}").footbot-menu__item Developers
-        router-link(:to="{ name: 'community'}").footbot-menu__item Community
         a(href="https://github.com/cosmos/cosmos-sdk" target="_blank").footbot-menu__item Cosmos SDK
-        a(href="https://tendermint.com" target="_blank").footbot-menu__item Tendermint
+        a(href="https://github.com/cosmos/voyager" target="_blank").footbot-menu__item Cosmos Voyager
+        a(href="https://github.com/tendermint/tendermint" target="_blank").footbot-menu__item Tendermint Core
+        a(href="https://github.com/keppel/lotion" target="_blank").footbot-menu__item Lotion
 </template>
 
 <script>

--- a/src/components/common/AppFooter.vue
+++ b/src/components/common/AppFooter.vue
@@ -36,10 +36,20 @@ export default {
     SectionSocial
   },
   computed: {
-    isPageCommunity() {
-      return this.$router.currentRoute.name === "community"
-    },
-    ...mapGetters(["links", "config"])
+    ...mapGetters(["config"])
+  },
+  data: () => ({
+    isPageCommunity: false
+  }),
+  methods: {
+    getRouteName() {
+      return this.$router.currentRoute.name
+    }
+  },
+  watch: {
+    $route() {
+      this.isPageCommunity = this.$route.name === "community"
+    }
   }
 }
 </script>

--- a/src/components/common/AppHeader.vue
+++ b/src/components/common/AppHeader.vue
@@ -12,10 +12,10 @@ header.app-header
         router-link(to='/intro' @click.native='close') Introduction
         router-link(to='/testnet' @click.native='close') Testnet
         router-link(to='/roadmap' @click.native='close') Roadmap
+        router-link(to='/community' @click.native='close') Community
         router-link(to='/developers' @click.native='close') Developers
         router-link(to='/validators' @click.native='close') Validators
         router-link(to='/resources' @click.native='close') Resources
-        router-link(to='/about' @click.native='close') About
       nav
         a(:href='links.cosmos.blog' @click.native='close' target='_blank')
           span.label Blog

--- a/src/components/pages/PageCommunity.vue
+++ b/src/components/pages/PageCommunity.vue
@@ -3,17 +3,6 @@ page.page-community(
   title="Community"
   subtitle="These are the only official Cosmos communication channels.")
 
-  part(title="Social Media"): .community-cards
-    card-social(
-      dt="Twitter"
-      dd="Follow @cosmos, our official account"
-      icon="twitter"
-      :anchor="links.cosmos.community.twitter")
-    card-social(
-      dt="Medium"
-      dd="Read the latest on the Cosmos Blog"
-      icon="medium"
-      :anchor="links.cosmos.blog")
   part(title="Chat"): .community-cards
     card-social(
       dt="Community Chat"
@@ -61,6 +50,17 @@ page.page-community(
       dd="Subscribe to /r/cosmosnetwork"
       icon="reddit"
       :anchor="links.cosmos.community.reddit")
+  part(title="Social Media"): .community-cards
+    card-social(
+      dt="Twitter"
+      dd="Follow @cosmos, our official account"
+      icon="twitter"
+      :anchor="links.cosmos.community.twitter")
+    card-social(
+      dt="Medium"
+      dd="Read the latest on the Cosmos Blog"
+      icon="medium"
+      :anchor="links.cosmos.blog")
 </template>
 
 <script>

--- a/src/components/pages/PageCommunity.vue
+++ b/src/components/pages/PageCommunity.vue
@@ -14,6 +14,42 @@ page.page-community(
       dd="Read the latest on the Cosmos Blog"
       icon="medium"
       :anchor="links.cosmos.blog")
+  part(title="Chat"): .community-cards
+    card-social(
+      dt="Community Chat"
+      dd="Join #cosmos:matrix.org"
+      icon-type="mi"
+      icon="chat"
+      :anchor="links.cosmos.community.matrix")
+    card-social(
+      dt="Cosmos SDK Chat"
+      dd="Join #cosmos-sdk:matrix.org"
+      icon-type="mi"
+      icon="chat"
+      anchor="https://riot.im/app/#/room/#cosmos-sdk:matrix.org")
+    card-social(
+      dt="Cosmos Validator Chat"
+      dd="Join #cosmos_validators:matrix.org"
+      icon-type="mi"
+      icon="chat"
+      anchor="https://riot.im/app/#/room/#cosmos_validators:matrix.org")
+    card-social(
+      dt="Tendermint Chat"
+      dd="Join #tendermint:matrix.org"
+      icon-type="mi"
+      icon="chat"
+      anchor="https://riot.im/app/#/room/#tendermint:matrix.org")
+    card-social(
+      dt="Ethermint Chat"
+      dd="Join #ethermint:matrix.org"
+      icon-type="mi"
+      icon="chat"
+      anchor="https://riot.im/app/#/room/#ethermint:matrix.org")
+    card-social(
+      dt="Telegram"
+      dd="Join cosmosproject on Telegram"
+      icon="telegram"
+      :anchor="links.cosmos.community.telegram")
   part(title="Forums"): .community-cards
     card-social(
       dt="Official Forum"
@@ -25,36 +61,6 @@ page.page-community(
       dd="Subscribe to /r/cosmosnetwork"
       icon="reddit"
       :anchor="links.cosmos.community.reddit")
-  part(title="Chat"): .community-cards
-    card-social(
-      dt="Community Chat"
-      dd="Join cosmosproject on Telegram"
-      icon="telegram"
-      :anchor="links.cosmos.community.telegram")
-    card-social(
-      dt="Developer Chat"
-      dd="Join #cosmos:matrix.org"
-      icon-type="mi"
-      icon="chat"
-      :anchor="links.cosmos.community.matrix")
-    card-social(
-      dt="Cosmos-SDK Chat"
-      dd="Join #cosmos-sdk:matrix.org"
-      icon-type="mi"
-      icon="chat"
-      anchor="https://riot.im/app/#/room/#cosmos-sdk:matrix.org")
-    card-social(
-      dt="Validator Chat"
-      dd="Join #cosmos_validators:matrix.org"
-      icon-type="mi"
-      icon="chat"
-      anchor="https://riot.im/app/#/room/#cosmos_validators:matrix.org")
-    card-social(
-      dt="Tendermint Chat"
-      dd="Join #tendermint:matrix.org"
-      icon-type="mi"
-      icon="chat"
-      anchor="https://riot.im/app/#/room/#tendermint:matrix.org")
 </template>
 
 <script>

--- a/src/components/pages/PageIntroHub.vue
+++ b/src/components/pages/PageIntroHub.vue
@@ -2,6 +2,9 @@
 page(title="What is the Cosmos Hub?" subtitle="The Cosmos Hub is the first hub zone on the Cosmos Network.")
   div(slot="menu"): btn(icon="chat" value="Community Chat" type="anchor" href="https://riot.im/app/#/group/+cosmos:matrix.org" target="_blank" color="primary")
   text-container(url="https://api.github.com/repos/tendermint/aib-data/contents/md/intro-hub.md?ref=peng/testnet-refactor")
+  text-container
+    h4 Next&hellip;
+    btn(value="Going Further" type="link" :to="{ name: 'intro-further' }" icon="chevron_right" icon-pos="right" color="primary" size="lg")
 </template>
 
 <script>

--- a/src/components/pages/PageIntroIndex.vue
+++ b/src/components/pages/PageIntroIndex.vue
@@ -2,6 +2,9 @@
 page(title="What is Cosmos?" subtitle="Get started with an overview of the Cosmos Network.")
   div(slot="menu"): btn(icon="chat" value="Community Chat" type="anchor" href="https://riot.im/app/#/group/+cosmos:matrix.org" target="_blank" color="primary")
   text-container(url="https://api.github.com/repos/tendermint/aib-data/contents/md/intro-index.md?ref=peng/testnet-refactor")
+  text-container
+    h4 Next&hellip;
+    btn(value="Introduction to Cosmos Hub" type="link" :to="{ name: 'intro-hub' }" icon="chevron_right" icon-pos="right" color="primary" size="lg")
 </template>
 
 <script>

--- a/src/components/pages/PageResources.vue
+++ b/src/components/pages/PageResources.vue
@@ -6,7 +6,6 @@
     router-link(:to="{name: 'faq'}") FAQ
     router-link(:to="{name: 'plan'}") Plan
     router-link(:to="{name: 'delegators'}") Delegators
-    router-link(:to="{name: 'validator-faq'}") Validators
   router-view
 </template>
 

--- a/src/components/pages/PageValidators.vue
+++ b/src/components/pages/PageValidators.vue
@@ -2,6 +2,7 @@
 .page
   page-menu
     router-link(:to="{ name: 'validators'}") Overview
+    router-link(:to="{name: 'validator-faq'}") FAQ
     router-link(:to="{ name: 'testnet-tutorial'}") Testnet Tutorial
   router-view
 </template>

--- a/src/components/pages/PageValidatorsIndex.vue
+++ b/src/components/pages/PageValidatorsIndex.vue
@@ -7,6 +7,9 @@ page(
     btn(icon="chat" value="Validator Forum" type="anchor" href="https://forum.cosmos.network/c/validating" target="_blank")
   text-container(
     url='https://api.github.com/repos/tendermint/aib-data/contents/md/validators-index.md?ref=peng/testnet-refactor')
+  text-container
+    h4 Next&hellip;
+    btn(value="Validator FAQ" type="link" :to="{ name: 'validator-faq' }" icon="chevron_right" icon-pos="right" color="primary" size="lg")
 </template>
 
 <script>

--- a/src/components/sections/SectionCover.vue
+++ b/src/components/sections/SectionCover.vue
@@ -8,6 +8,13 @@ mixin actions(size)
       size=size
       color="primary"
       value="Join Testnet")
+    btn(
+      type="anchor"
+      href="http://explorer.cosmos.network"
+      icon="wifi_tethering"
+      size="lg"
+      target="_blank"
+      value="Testnet LIVE")
 
   form.action(action="//network.us14.list-manage.com/subscribe/post?u=1b8aeaa81ca615914eb2eb7fc&id=64c73f9f5f" method="post" name="mc-embedded-subscribe-form" target="_blank" novalidate="")
     field(name="EMAIL" type="email" placeholder="name@email.com" size=size)
@@ -15,7 +22,7 @@ mixin actions(size)
       type="submit"
       icon="email"
       size=size
-      color="primary")
+      value="Get Launch Alert")
     div(style="position: absolute; left: -5000px;" aria-hidden="true")
       input(type="text" name="b_1b8aeaa81ca615914eb2eb7fc_64c73f9f5f" tabindex="-1" value="")
 
@@ -72,18 +79,8 @@ export default {
       margin-bottom 0.25rem
       shadow()
 
-  div.action
     .ni-btn
       width 100%
-
-  form.action
-    display flex
-    .ni-btn .ni-btn__container
-      border-radius 0 0.25rem 0.25rem 0
-    .ni-field
-      flex 1
-      border-right none
-      background alpha(app-bg, 50%)
 
 .section-cover__scroll
   position absolute

--- a/src/components/sections/SectionSocial.vue
+++ b/src/components/sections/SectionSocial.vue
@@ -1,13 +1,14 @@
 <template lang="pug">
 .section-social: .section-social__container
   .app-footer__row.app-footer__row-actions
-    part(title="Get Started")
+    part(title="Testnet Status: LIVE")
       btn(
-        type="link"
-        :to="{ name: 'whitepaper'}"
+        type="anchor"
+        href="http://explorer.cosmos.network"
+        icon="assessment"
         size="lg"
-        icon="description"
-        value="Read Whitepaper")
+        target="_blank"
+        value="Testnet Explorer")
     part(title="Get Newsletter"): form-email-signup
   .app-footer__row
     part(title='Discuss & Chat'): .community-cards

--- a/src/components/sections/SectionSocial.vue
+++ b/src/components/sections/SectionSocial.vue
@@ -12,20 +12,23 @@
   .app-footer__row
     part(title='Discuss & Chat'): .community-cards
       card-social(
-        dt='Community Chat'
-        dd='Join cosmosproject on Telegram'
-        icon='telegram'
-        :anchor='links.cosmos.community.telegram')
+        dt="Community Chat"
+        dd="Join #cosmos:matrix.org"
+        icon-type="mi"
+        icon="chat"
+        :anchor="links.cosmos.community.matrix")
       card-social(
-        dt='Developer Chat'
-        dd='Join #cosmos:matrix.org with Riot'
-        icon='rocketchat'
-        :anchor='links.cosmos.community.matrix')
+        dt="Cosmos SDK Chat"
+        dd="Join #cosmos-sdk:matrix.org"
+        icon-type="mi"
+        icon="chat"
+        anchor="https://riot.im/app/#/room/#cosmos-sdk:matrix.org")
       card-social(
-        dt='Forum'
-        dd='Discuss the Cosmos Network'
-        icon='discourse'
-        :anchor='links.cosmos.community.discourse')
+        dt="Cosmos Validator Chat"
+        dd="Join #cosmos_validators:matrix.org"
+        icon-type="mi"
+        icon="chat"
+        anchor="https://riot.im/app/#/room/#cosmos_validators:matrix.org")
     part(title='Social Media'): .community-cards
       card-social(
         dt='Medium'

--- a/src/components/sections/SectionSocial.vue
+++ b/src/components/sections/SectionSocial.vue
@@ -5,7 +5,7 @@
       btn(
         type="anchor"
         href="http://explorer.cosmos.network"
-        icon="assessment"
+        icon="wifi_tethering"
         size="lg"
         target="_blank"
         value="Testnet Explorer")

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -115,7 +115,7 @@ const routes = [
       },
       {
         path: "whitepaper/:locale",
-        name: "whitepaper",
+        name: "whitepaper-i18n",
         component: PageResourcesWhitepaper
       },
       {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -98,6 +98,11 @@ const routes = [
         path: "tutorial",
         name: "testnet-tutorial",
         component: PageValidatorsTestnet
+      },
+      {
+        path: "faq",
+        name: "validator-faq",
+        component: PageResourcesValidators
       }
     ]
   },
@@ -132,11 +137,6 @@ const routes = [
         path: "delegators",
         name: "delegators",
         component: PageResourcesDelegators
-      },
-      {
-        path: "validator-faq",
-        name: "validator-faq",
-        component: PageResourcesValidators
       }
     ]
   },
@@ -193,6 +193,7 @@ const routes = [
   },
   { path: "/plan", redirect: "/resources/plan" },
   { path: "/plan/:locale", redirect: "/resources/plan" },
+  { path: "/resources/validator-faq", redirect: "/validators/faq" },
   {
     path: "/riot",
     beforeEnter: () => {
@@ -210,7 +211,7 @@ const routes = [
   },
   { path: "/staking", redirect: "/intro/hub" },
   { path: "/staking/validators", redirect: "/validators" },
-  { path: "/staking/validators-faq", redirect: "/resources/validator-faq" },
+  { path: "/staking/validators-faq", redirect: "/validators/faq" },
   { path: "/staking/delegators", redirect: "/resources/delegators" },
   { path: "/team", redirect: "/about" },
   {
@@ -223,8 +224,6 @@ const routes = [
   { path: "/ui", redirect: "/voyager" },
   { path: "/validate", redirect: "/validators/tutorial" },
   { path: "/validator", redirect: "/staking/validators" },
-  { path: "/validators/faq", redirect: "/resources/validator-faq" },
-  { path: "/validators-faq", redirect: "/resources/validator-faq" },
   { path: "/whitepaper/en-US", redirect: "/resources/whitepaper" },
   { path: "/whitepaper", redirect: "/resources/whitepaper" },
   { path: "/wallet", redirect: "/developers/wallet" },


### PR DESCRIPTION
Based on last all-hands meeting, we decided to update the website with a few things. I'm going to merge this with admin privileges to get it out ASAP.

- [x] better header and footer link organization, with header showing Community and footer linking to pages that aren't on the site header
- [x] reduce site's focus on Telegram, increase focus on Matrix/Riot
- [x] move Validator FAQ to `/validators/faq`
- [x] Add `Next` buttons to Intro, Intro to Hub, and Validators Overview
- [x] Link to Testnet Explorer in footer
- [x] Link to Testnet Explorer on homepage