### PR TITLE
Move algolia bump to backend

### DIFF
--- a/src/views/Ecosystem.vue
+++ b/src/views/Ecosystem.vue
@@ -110,7 +110,6 @@
 
 <script>
 import algoliasearch from "algoliasearch"
-import axios from "axios"
 import TmHeader from "common/TmHeader"
 import TmSection from "common/TmSection"
 import TmBtn from "common/TmBtn"
@@ -118,12 +117,7 @@ import SectionMessari from "sections/SectionMessari"
 import IconDot from "common/IconDot"
 
 const searchApiKey = process.env.VUE_APP_ALGOLIA_SEARCH_API_KEY
-const adminApiKey = process.env.VUE_APP_ALGOLIA_ADMIN_API_KEY
-
 const searchClient = algoliasearch("ME7376U3XW", searchApiKey)
-const client = algoliasearch("ME7376U3XW", adminApiKey)
-
-const index = client.initIndex("apps")
 
 export default {
   name: "page-ecosystem",
@@ -147,33 +141,10 @@ export default {
         proofofconcept: "#3B427D",
         beta: "#66A1FF",
         alpha: "#BCE7FF"
-      },
-      records: []
+      }
     }
   },
-  beforeMount() {
-    this.getAirtableData()
-  },
   methods: {
-    async getAirtableData() {
-      await axios({
-        url: "https://cosmos-ecosystem-api.vercel.app/apps"
-      }).then(res => {
-        res.data.records.forEach(rec => {
-          if (rec.fields.active && rec.fields.status !== "Deprecated") {
-            this.records.push(rec.fields)
-          }
-        })
-
-        index.replaceAllObjects(this.records, {
-          autoGenerateObjectIDIfNotExist: true
-        })
-        //- .then(({ objectIDs }) => {
-        //-   // eslint-disable-next-line
-        //-   console.log(objectIDs)
-        //- })
-      })
-    },
     moveToTheEnd(arr, word) {
       arr.map((elem, index) => {
         if (elem.label.toLowerCase() === word.toLowerCase()) {

--- a/src/views/Wallets.vue
+++ b/src/views/Wallets.vue
@@ -111,15 +111,9 @@ import TmHeader from "common/TmHeader"
 import TmSection from "common/TmSection"
 import TmBtn from "common/TmBtn"
 import SectionMessari from "sections/SectionMessari"
-import axios from "axios"
 
 const searchApiKey = process.env.VUE_APP_ALGOLIA_SEARCH_API_KEY
-const adminApiKey = process.env.VUE_APP_ALGOLIA_ADMIN_API_KEY
-
 const searchClient = algoliasearch("ME7376U3XW", searchApiKey)
-const client = algoliasearch("ME7376U3XW", adminApiKey)
-
-const index = client.initIndex("wallets")
 
 export default {
   name: "page-wallets",
@@ -134,33 +128,10 @@ export default {
   },
   data() {
     return {
-      searchClient: searchClient,
-      records: []
+      searchClient: searchClient
     }
   },
-  beforeMount() {
-    this.getAirtableData()
-  },
   methods: {
-    async getAirtableData() {
-      await axios({
-        url: "https://cosmos-ecosystem-api.vercel.app/wallets"
-      }).then(res => {
-        res.data.records.forEach(rec => {
-          if (rec.fields.active) {
-            this.records.push(rec.fields)
-          }
-        })
-
-        index.replaceAllObjects(this.records, {
-          autoGenerateObjectIDIfNotExist: true
-        })
-        //- .then(({ objectIDs }) => {
-        //-   // eslint-disable-next-line
-        //-   console.log(objectIDs)
-        //- })
-      })
-    },
     ledgerItems(items) {
       return items.map(item => ({
         ...item,


### PR DESCRIPTION
- clean up algolia admin index
- remove fetching airtable API on ecosystem.vue and wallets.vue

new repo: https://github.com/lovincyrus/algolia-bump

Related: https://github.com/allinbits/design/issues/378