### PR TITLE
Update blogrss URL

### DIFF
--- a/src/store/modules/blog.js
+++ b/src/store/modules/blog.js
@@ -8,9 +8,7 @@ const state = {
 const mutations = {
   async initializeBlog(state) {
     const parser = new RSSParser()
-    // https://github.com/allinbits/design/issues/374
-    // TODO: update https://blogrss.cosmos.network/
-    let feed = await parser.parseURL("https://cosmos-blog.glitch.me/")
+    let feed = await parser.parseURL("https://feed.blog.cosmos.network")
     state.posts = feed.items
   }
 }


### PR DESCRIPTION
closes https://github.com/allinbits/design/issues/374

It seems like medium has added an extra layer of protection. Helder created another custom backend.

[`https://feed.blog.cosmos.network`](https://feed.blog.cosmos.network)

- [x] replace temp glitch api with custom feed go api