### PR TITLE
Fix swagger base URL

### DIFF
--- a/src/views/Api.vue
+++ b/src/views/Api.vue
@@ -115,7 +115,7 @@ export default {
       const dom_id = "#swagger"
       if (host) {
         spec.host = host
-      }
+      } else spec.host = "api.cosmos.network"
       this.host = spec.host
       if (version) {
         this.spec = SwaggerUI({ dom_id, spec })


### PR DESCRIPTION
- [x] bypass `host` from swagger yaml
- [x] use hardcoded api.cosmos.network
- [x] users can set their custom base URL 

Ref: https://github.com/cosmos/cosmos-sdk/issues/8755

closes https://github.com/allinbits/design/issues/388