### PR TITLE
Add proxy redirect of /hub

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/*    /index.html   200
-/hub/* https://cosmos-hub-site.netlify.com/:splat 200!
+/*      /index.html                                 200
+/hub/*  https://cosmos-hub-site.netlify.com/:splat  200!

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
 /*    /index.html   200
+/hub/* https://cosmos-hub-site.netlify.com/:splat 200!

--- a/src/router.js
+++ b/src/router.js
@@ -378,10 +378,10 @@ const routes = [
     path: "/404",
     component: () => import(/* webpackChunkName: "404" */ "./views/404.vue")
   },
-  // {
-  //   path: "*",
-  //   component: () => import(/* webpackChunkName: "404" */ "./views/404.vue")
-  // },
+  {
+    path: "*",
+    component: () => import(/* webpackChunkName: "404" */ "./views/404.vue")
+  },
   {
     path: "/newsletters/",
     component: Newsletters

--- a/src/router.js
+++ b/src/router.js
@@ -262,6 +262,10 @@ const routes = [
     component: Contributors
   },
   {
+    path: "/hub/*",
+    redirect: "/hub",
+  },
+  {
     path: "/goz/*",
     redirect: "/goz",
     pathToRegexpOptions: { strict: true }

--- a/src/router.js
+++ b/src/router.js
@@ -378,16 +378,10 @@ const routes = [
     path: "/404",
     component: () => import(/* webpackChunkName: "404" */ "./views/404.vue")
   },
-  {
-    path: "*",
-    component: () => import(/* webpackChunkName: "404" */ "./views/404.vue")
-  },
-  {
-    path: "/newsletters/2020-03*",
-    beforeEnter: () => {
-      window.location.assign("/newsletters/community/2020-03")
-    }
-  },
+  // {
+  //   path: "*",
+  //   component: () => import(/* webpackChunkName: "404" */ "./views/404.vue")
+  // },
   {
     path: "/newsletters/",
     component: Newsletters

--- a/src/router.js
+++ b/src/router.js
@@ -262,10 +262,6 @@ const routes = [
     component: Contributors
   },
   {
-    path: "/hub/*",
-    redirect: "/hub",
-  },
-  {
     path: "/goz/*",
     redirect: "/goz",
     pathToRegexpOptions: { strict: true }


### PR DESCRIPTION
https://deploy-preview-182--cosmos-network.netlify.app/hub

Ref: https://github.com/allinbits/design/issues/398

Proxy redirect: `/hub/*  https://cosmos-hub-site.netlify.app/:splat  200!`

- [x] ~~check https://deploy-preview-182--cosmos-network.netlify.app/hub after removing * wildroute that goes to 404 in router.js~~
- [x] ~~add a /hubs/* to redirect to /hub~~
- [x] Ping Netlify Support
- [ ] how to redirect /hub → cosmos-hub-site.netlify.com on CDN level successfully? Currently, /* goes to 404 if the path is not specified.

❌ Vue SPA
![image](https://user-images.githubusercontent.com/1021101/111230363-be5f9d00-85a4-11eb-9874-43ab36efc548.png)

✅ Nuxt SSR
![image](https://user-images.githubusercontent.com/1021101/111230968-ab999800-85a5-11eb-8d93-a6154f132522.png)


## References
1. https://docs.netlify.com/routing/redirects/rewrites-proxies/
2. https://docs.netlify.com/routing/redirects/rewrites-proxies/#history-pushstate-and-single-page-apps
3. https://answers.netlify.com/t/redirect-rule-not-works-from-external/18735
4. https://answers.netlify.com/t/support-guide-direct-links-to-my-single-page-app-spa-dont-work/126/2
5. Splat redirect works on Nuxt SSR but not Vue SPA. → https://cosmos-design.netlify.app/hub
6. https://www.netlify.com/blog/2020/04/07/creating-better-more-predictable-redirect-rules-for-spas/