### PR TITLE
Fix icon animation for external contained buttons

### DIFF
--- a/components/TmButton.vue
+++ b/components/TmButton.vue
@@ -386,7 +386,7 @@ export default {
       transform translateX(-10%)
     >>> .icon__down
       transform translateY(10%)
-    .tm-button__external&
+    .tm-button__external.tm-button__variant__text&
       >>> .icon__right
         transform translate(10%, -10%)
       >>> .icon__down


### PR DESCRIPTION
Fixes a visual animation issue where the icon for external `contained` buttons are moving upwards, which is inconsistent with other buttons of the same type. This PR adds the `tm-button__variant__text` class to specifically target `text` buttons when applying the upwards animation. Please disregard this PR if this behavior is intentional.

### Before
![learn-bug](https://user-images.githubusercontent.com/4630488/112884166-07731f00-9084-11eb-8f89-118663a5c577.gif)

### After
![learn-fixed](https://user-images.githubusercontent.com/4630488/112884185-0cd06980-9084-11eb-92d9-3f918450d5f9.gif)

External `text` icon remains unchanged.

### Before
![community-before](https://user-images.githubusercontent.com/4630488/112884233-1954c200-9084-11eb-99ba-5525226442a2.gif)

### After
![community-after](https://user-images.githubusercontent.com/4630488/112884245-1d80df80-9084-11eb-8408-21283f3a20a2.gif)