### PR TITLE
tm-link Tweaks

### DIFF
--- a/assets/app.styl
+++ b/assets/app.styl
@@ -1,1 +1,0 @@
-// moved to _base.styl

--- a/assets/styles/_base.styl
+++ b/assets/styles/_base.styl
@@ -15,6 +15,10 @@ html
   font-kerning normal
   text-rendering optimizeLegibility
 
+h1, h2, h3, h4, h5, h6
+  margin-top 0
+  margin-bottom 0
+
 @supports (font-variation-settings: normal)
   html
     font-family $font-family-sans-serif-var

--- a/components/SectionForm.vue
+++ b/components/SectionForm.vue
@@ -58,7 +58,9 @@
             </form>
             <p class="bottom__footnote tm-measure tm-rf-1 tm-lh-copy">
               Unsubscribe at any time.
-              <a href="https://cosmos.network/privacy">Privacy policy</a>
+              <tm-link href="https://v1.cosmos.network/privacy"
+                >Privacy policy</tm-link
+              >
             </p>
           </div>
         </transition>

--- a/components/SectionPrimaryNav.vue
+++ b/components/SectionPrimaryNav.vue
@@ -31,7 +31,7 @@
                         <li>
                           <tm-link
                             href="https://v1.cosmos.network/intro"
-                            class="tm-rf0 tm-lh-title tm-link tm-link-external"
+                            class="tm-rf0 tm-lh-title tm-link-external"
                             >Introduction</tm-link
                           >
                         </li>
@@ -63,7 +63,7 @@
                         <li>
                           <tm-link
                             href="https://tutorials.cosmos.network"
-                            class="tm-rf0 tm-lh-title tm-link tm-link-external"
+                            class="tm-rf0 tm-lh-title tm-link-external"
                           >
                             <span>Tutorials</span></tm-link
                           >
@@ -71,7 +71,7 @@
                         <li>
                           <tm-link
                             href="https://docs.cosmos.network"
-                            class="tm-rf0 tm-lh-title tm-link tm-link-external"
+                            class="tm-rf0 tm-lh-title tm-link-external"
                           >
                             <span>Documentation</span></tm-link
                           >
@@ -86,7 +86,7 @@
                         <li>
                           <tm-link
                             href="https://v1.cosmos.network/sdk"
-                            class="tm-rf0 tm-lh-title tm-link tm-link-external"
+                            class="tm-rf0 tm-lh-title tm-link-external"
                           >
                             <span>Cosmos SDK</span></tm-link
                           >
@@ -94,7 +94,7 @@
                         <li>
                           <tm-link
                             href="https://ibcprotocol.org"
-                            class="tm-rf0 tm-lh-title tm-link tm-link-external"
+                            class="tm-rf0 tm-lh-title tm-link-external"
                           >
                             <span>IBC</span></tm-link
                           >
@@ -130,7 +130,7 @@
                         <li>
                           <tm-link
                             href="https://v1.cosmos.network/community"
-                            class="tm-rf0 tm-lh-title tm-link tm-link-external"
+                            class="tm-rf0 tm-lh-title tm-link-external"
                           >
                             <span>Community</span></tm-link
                           >
@@ -138,7 +138,7 @@
                         <li>
                           <tm-link
                             href="https://v1.cosmos.network/events"
-                            class="tm-rf0 tm-lh-title tm-link tm-link-external"
+                            class="tm-rf0 tm-lh-title tm-link-external"
                           >
                             <span>Events</span></tm-link
                           >
@@ -146,7 +146,7 @@
                         <li>
                           <tm-link
                             href="https://v1.cosmos.network/contributors"
-                            class="tm-rf0 tm-lh-title tm-link tm-link-external"
+                            class="tm-rf0 tm-lh-title tm-link-external"
                           >
                             <span>Contributors</span></tm-link
                           >

--- a/components/SectionSecondaryNav.vue
+++ b/components/SectionSecondaryNav.vue
@@ -29,12 +29,10 @@
           >
         </li>
         <li>
-          <a
+          <tm-link
             href="https://hub.cosmos.network"
-            target="_blank"
-            rel="noreferrer noopener"
-            class="tm-rf-1 tm-medium tm-lh-title tm-link tm-link-external"
-            >Documentation</a
+            class="tm-rf-1 tm-medium tm-lh-title tm-link-external"
+            >Documentation</tm-link
           >
         </li>
       </ul>

--- a/components/TmButton.vue
+++ b/components/TmButton.vue
@@ -20,7 +20,7 @@
     </span>
   </nuxt-link>
   <!-- EXTERNAL -->
-  <a
+  <tm-link
     v-else-if="toLink === 'external'"
     :href="href"
     target="_blank"
@@ -41,7 +41,7 @@
     <span class="tm-button__content">
       <slot />
     </span>
-  </a>
+  </tm-link>
   <!-- DISABLED -->
   <button
     v-else-if="disabled"

--- a/components/TmCtaCards.vue
+++ b/components/TmCtaCards.vue
@@ -17,13 +17,7 @@
           </div>
           <div class="title tm-rf2 tm-bold tm-lh-title">{{ item.title }}</div>
         </nuxt-link>
-        <a
-          v-else
-          :href="item.href"
-          target="_blank"
-          rel="noreferrer noopener"
-          class="card-item"
-        >
+        <tm-link v-else :href="item.href" class="card-item">
           <div v-if="item.graphics" class="graphics">
             <component :is="`${item.graphics}`" class="graphics__item" />
           </div>
@@ -35,7 +29,7 @@
           <div class="title tm-rf2 tm-bold tm-lh-title tm-title">
             {{ item.title }}
           </div>
-        </a>
+        </tm-link>
       </div>
     </div>
   </div>

--- a/components/TmFooter.vue
+++ b/components/TmFooter.vue
@@ -27,25 +27,19 @@
           <logo-cosmos-wordmark class="logo__cosmos" />
           <span class="sr-only">Cosmos</span>
         </nuxt-link>
-        <a
-          href="https://cosmos.network/privacy"
-          target="_blank"
-          rel="noreferrer noopener"
-          class="tm-link privacy"
-          >Privacy</a
+        <tm-link href="https://v1.cosmos.network/privacy" class="privacy"
+          >Privacy</tm-link
         >
       </nav>
       <nav ref="links" class="social-icons" role="navigation">
-        <a
+        <tm-link
           v-for="link in links"
           :key="url(link)"
           v-tooltip="{
             content: link.title,
           }"
           :href="url(link)"
-          class="social-icons__item tm-link"
-          target="_blank"
-          rel="noreferrer"
+          class="social-icons__item"
         >
           <svg
             width="24"
@@ -57,7 +51,7 @@
           >
             <path :d="icon(link)" style="pointer-events: none"></path>
           </svg>
-        </a>
+        </tm-link>
       </nav>
     </div>
     <p class="smallprint tm-rf-1 tm-lh-copy">

--- a/components/TmLink.vue
+++ b/components/TmLink.vue
@@ -1,8 +1,38 @@
 <template>
+  <!-- TODO: remove this <a> when we're no longer redirecting back to v1.cosmos.network -->
   <a
+    v-if="isOldLink(href)"
+    :href="href"
+    :class="['tm-link', hoverUnderline && 'tm-link-underline-hover']"
+  >
+    <slot></slot>
+  </a>
+  <a
+    v-else-if="checkLink === 'external'"
     :href="href"
     target="_blank"
     rel="noopener noreferrer"
+    :class="['tm-link', hoverUnderline && 'tm-link-underline-hover']"
+  >
+    <slot></slot>
+  </a>
+  <nuxt-link
+    v-else-if="checkLink === 'internal'"
+    :to="href"
+    :class="['tm-link', hoverUnderline && 'tm-link-underline-hover']"
+  >
+    <slot></slot>
+  </nuxt-link>
+  <a
+    v-else-if="checkLink === 'anchor'"
+    :v-scroll-to="href"
+    :class="['tm-link', hoverUnderline && 'tm-link-underline-hover']"
+  >
+    <slot></slot>
+  </a>
+  <a
+    v-else
+    :href="href"
     :class="['tm-link', hoverUnderline && 'tm-link-underline-hover']"
   >
     <slot></slot>
@@ -17,9 +47,48 @@ export default {
       default: '#',
       required: true,
     },
+    to: {
+      type: String,
+      default: null,
+    },
     hoverUnderline: {
       type: Boolean,
       default: false,
+    },
+  },
+  computed: {
+    /*
+      default - <a href="">
+      external - <a href="" target="_blank" rel="noreferrer noopener">
+      internal - <nuxt-link to="/features">
+      anchor - <a href="" v-scroll-to="">
+    */
+    checkLink() {
+      const url = this.href
+      if (this.isExternal(url)) return 'external'
+      if (this.isInternal(url)) return 'internal'
+      if (this.isAnchor(url)) return 'anchor'
+      return 'default'
+    },
+  },
+  methods: {
+    // http | https
+    isExternal(url) {
+      const regex = /^(http|https):\/\//
+      return regex.test(String(url))
+    },
+    isInternal(url) {
+      return url.startsWith('/')
+    },
+    // TODO: regex `/features#gravity-bridge`
+    isAnchor(url) {
+      return url.includes('#')
+    },
+    // TODO: to be removed
+    // http://v1.cosmos.network || https://v1.cosmos.network
+    isOldLink(url) {
+      const regex = /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?v1/
+      return regex.test(String(url))
     },
   },
 }

--- a/components/content/buildDropdownTop.vue
+++ b/components/content/buildDropdownTop.vue
@@ -6,13 +6,13 @@
           href="https://tutorials.cosmos.network"
           class="dropdown-wrap__content"
         >
-          <span>Tutorials</span></tm-link
+          <span class="tm-link-external">Tutorials</span></tm-link
         >
         <tm-link
           href="https://docs.cosmos.network"
           class="dropdown-wrap__content"
         >
-          <span>Documentation</span></tm-link
+          <span class="tm-link-external">Documentation</span></tm-link
         >
       </div>
       <div class="right">
@@ -32,7 +32,9 @@
             <img src="~/static/symbols/sdk.svg" />
           </div>
           <div class="text">
-            <div class="title tm-rf0 tm-lh-copy">Cosmos SDK</div>
+            <div class="title tm-rf0 tm-lh-copy tm-link-external">
+              Cosmos SDK
+            </div>
             <div class="desc tm-rf-1 tm-lh-copy">
               Build or extend a blockchain
             </div>

--- a/components/content/exploreDropdownTop.vue
+++ b/components/content/exploreDropdownTop.vue
@@ -17,19 +17,19 @@
           href="https://v1.cosmos.network/community"
           class="dropdown-wrap__content"
         >
-          <span>Community</span></tm-link
+          <span class="tm-link-external">Community</span></tm-link
         >
         <tm-link
           href="https://v1.cosmos.network/events"
           class="dropdown-wrap__content"
         >
-          <span>Events</span></tm-link
+          <span class="tm-link-external">Events</span></tm-link
         >
         <tm-link
           href="https://v1.cosmos.network/contributors"
           class="dropdown-wrap__content"
         >
-          <span>Contributors</span></tm-link
+          <span class="tm-link-external">Contributors</span></tm-link
         >
       </div>
     </div>

--- a/components/content/learnDropdownTop.vue
+++ b/components/content/learnDropdownTop.vue
@@ -6,7 +6,7 @@
           href="https://v1.cosmos.network/intro"
           class="dropdown-wrap__content"
         >
-          <span>Introduction</span></tm-link
+          <span class="tm-link-external">Introduction</span></tm-link
         >
         <tm-link href="/features" class="dropdown-wrap__content">
           <span>Features</span>

--- a/components/content/learnDropdownTop.vue
+++ b/components/content/learnDropdownTop.vue
@@ -8,9 +8,9 @@
         >
           <span>Introduction</span></tm-link
         >
-        <nuxt-link to="/features" class="dropdown-wrap__content">
+        <tm-link href="/features" class="dropdown-wrap__content">
           <span>Features</span>
-        </nuxt-link>
+        </tm-link>
       </div>
       <div class="right">
         <nuxt-link to="/learn/staking" class="dropdown-wrap__content">

--- a/components/ecosystem/CardToken.vue
+++ b/components/ecosystem/CardToken.vue
@@ -4,19 +4,17 @@
     <div class="token-name">
       <TokenLogo :item="item" />
       <div class="text log tm-rf1 tm-bold tm-lh-copy">
-        <a
+        <tm-link
           v-if="
             item &&
             item.fields &&
             item.fields.website &&
             item.fields.website !== 'x'
           "
-          rel="noreferrer noopener"
           :href="item.fields.website"
-          target="_blank"
         >
           {{ token.name }}
-        </a>
+        </tm-link>
         <span v-else>{{ token.name }}</span>
       </div>
     </div>

--- a/components/home/HomeSectionCommunity.vue
+++ b/components/home/HomeSectionCommunity.vue
@@ -19,12 +19,7 @@
     </div>
     <ul class="list">
       <li v-for="item in links" :key="item.logo" class="list-item">
-        <a
-          :href="item.url"
-          target="_blank"
-          rel="noreferrer noopener"
-          class="tm-link"
-        >
+        <tm-link :href="item.url">
           <div class="icon">
             <component :is="`icon-${item.logo}`" />
           </div>
@@ -38,7 +33,7 @@
               {{ item.desc }}
             </p>
           </div>
-        </a>
+        </tm-link>
       </li>
     </ul>
   </div>

--- a/components/home/HomeSectionDev.vue
+++ b/components/home/HomeSectionDev.vue
@@ -53,10 +53,7 @@
         </p>
       </div>
       <div class="card card-fundraising">
-        <a
-          href="https://v1.cosmos.network/contributors"
-          rel="noopener noreferrer"
-        >
+        <tm-link href="https://v1.cosmos.network/contributors">
           <div :strength="-5" class="card-inner" type="depth">
             <div
               :strength="-20"
@@ -82,7 +79,7 @@
               </p>
             </div>
           </div>
-        </a>
+        </tm-link>
       </div>
       <div class="card card-starport">
         <nuxt-link to="/starport" rel="noopener noreferrer">
@@ -146,10 +143,7 @@
     </div>
     <div class="cards">
       <div class="card card-connect">
-        <a
-          href="https://tutorials.cosmos.network/hello-world/tutorial/"
-          rel="noopener noreferrer"
-        >
+        <tm-link href="https://tutorials.cosmos.network/hello-world/tutorial/">
           <div :strength="-5" class="card-inner" type="depth">
             <div
               :strength="-10"
@@ -216,14 +210,10 @@
               </svg>
             </div>
           </div>
-        </a>
+        </tm-link>
       </div>
       <div class="card card-integrate">
-        <a
-          href="https://discord.gg/vcExX9T"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
+        <tm-link href="https://discord.gg/vcExX9T">
           <div :strength="-5" class="card-inner" type="depth">
             <div
               :strength="-10"
@@ -259,14 +249,10 @@
               </svg>
             </div>
           </div>
-        </a>
+        </tm-link>
       </div>
       <div class="card card-validate">
-        <a
-          href="https://discord.gg/g8vYRa9zQJ"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
+        <tm-link href="https://discord.gg/g8vYRa9zQJ">
           <div :strength="-5" class="card-inner" type="depth">
             <div
               :strength="-10"
@@ -307,7 +293,7 @@
               </svg>
             </div>
           </div>
-        </a>
+        </tm-link>
       </div>
     </div>
   </div>

--- a/components/home/HomeSectionEnd.vue
+++ b/components/home/HomeSectionEnd.vue
@@ -14,11 +14,7 @@
     </header>
     <div class="cards">
       <div class="card card-intro">
-        <a
-          href="https://v1.cosmos.network/intro"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
+        <tm-link href="https://v1.cosmos.network/intro">
           <div :strength="-5" class="card-inner" type="depth">
             <figure :strength="-10" tag="figure" class="card__graphics">
               <graphics-home-end-intro class="graphics" />
@@ -38,7 +34,7 @@
               </p>
             </div>
           </div>
-        </a>
+        </tm-link>
       </div>
       <div class="card card-atom">
         <nuxt-link to="learn/staking">

--- a/components/home/HomeSectionTech.vue
+++ b/components/home/HomeSectionTech.vue
@@ -16,7 +16,9 @@
     </header>
     <div class="text">
       <p class="tm-rf0 tm-rf1-m-up tm-lh-copy tm-measure-narrow">
-        <a href="cosmos.network/sdk" class="tm-link tm-medium">Cosmos SDK</a>
+        <tm-link href="https://github.com/cosmos/cosmos-sdk" class="tm-medium"
+          >Cosmos SDK</tm-link
+        >
         is a state-of-the-art blockchain framework that powers the Cosmos Hub
         and its rapidly expanding orbit of sovereign chains.
       </p>

--- a/pages/features.vue
+++ b/pages/features.vue
@@ -101,7 +101,7 @@
           <div class="mid">
             <tm-link
               href="https://medium.com/chainapsis/why-interchain-accounts-change-everything-for-cosmos-interoperability-59c19032bf11"
-              class="tm-link tm-link-external tm-rf3 tm-bold tm-lh-title"
+              class="tm-link-external tm-rf3 tm-bold tm-lh-title"
               >Interchain Accounts</tm-link
             >
             <div

--- a/pages/features.vue
+++ b/pages/features.vue
@@ -59,12 +59,8 @@
               </h3>
               <div class="desc tm-rf0 tm-lh-copy tm-measure-narrow">
                 Built on top of the
-                <a
-                  href="https://tendermint.com/core"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  class="tm-link tm-bold"
-                  >Tendermint BFT consensus engine</a
+                <tm-link href="https://tendermint.com/core" class="tm-bold"
+                  >Tendermint BFT consensus engine</tm-link
                 >, the Hub’s staking module is one of the most efficient
                 proof-of-stake implementations in the world. It enables ATOM
                 token holders to secure the chain by locking their ATOM, in
@@ -103,12 +99,10 @@
             <div class="caption tm-rf0 tm-lh-title">Account System · 2021</div>
           </div>
           <div class="mid">
-            <a
+            <tm-link
               href="https://medium.com/chainapsis/why-interchain-accounts-change-everything-for-cosmos-interoperability-59c19032bf11"
               class="tm-link tm-link-external tm-rf3 tm-bold tm-lh-title"
-              rel="noreferrer noopener"
-              target="_blank"
-              >Interchain Accounts</a
+              >Interchain Accounts</tm-link
             >
             <div
               class="desc tm-rf0 tm-lh-copy tm-measure tm-measure-narrow-l-up"
@@ -162,12 +156,10 @@
           </div>
           <div class="mid">
             <div class="title">
-              <a
+              <tm-link
                 href="https://github.com/tendermint/liquidity#liquidity-module"
-                class="tm-link tm-link-external tm-rf3 tm-bold tm-lh-title"
-                rel="noreferrer noopener"
-                target="_blank"
-                >Gravity DEX</a
+                class="tm-link-external tm-rf3 tm-bold tm-lh-title"
+                >Gravity DEX</tm-link
               >
             </div>
             <div class="desc tm-rf0 tm-lh-copy tm-measure">
@@ -219,14 +211,12 @@
           </div>
           <div class="mid">
             <h3 class="title">
-              <a
+              <tm-link
                 href="https://blog.althea.net/gravity-bridge"
-                class="tm-link tm-link-external tm-rf3 tm-bold tm-lh-title"
-                rel="noreferrer noopener"
-                target="_blank"
+                class="tm-link-external tm-rf3 tm-bold tm-lh-title"
               >
                 Gravity Bridge
-              </a>
+              </tm-link>
             </h3>
             <div class="desc tm-rf0 tm-lh-copy tm-measure">
               Backed by billions of dollars of ATOM staked on the Cosmos Hub,
@@ -279,12 +269,10 @@
           </div>
           <div class="mid">
             <h3 class="title">
-              <a
+              <tm-link
                 href="https://github.com/informalsystems/cross-chain-validation/blob/2b7e5ddebd10c9eea743989ca3fbcba990db4987/spec/valset-update-protocol.md"
-                class="tm-link tm-link-external tm-rf3 tm-bold tm-lh-title"
-                rel="noreferrer noopener"
-                target="_blank"
-                >Interchain Staking</a
+                class="tm-link-external tm-rf3 tm-bold tm-lh-title"
+                >Interchain Staking</tm-link
               >
             </h3>
             <div class="desc tm-rf0 tm-lh-copy tm-measure">
@@ -341,12 +329,10 @@
           </div>
           <div class="mid">
             <h3 class="title">
-              <a
+              <tm-link
                 href="https://github.com/tendermint/cns"
-                class="tm-link tm-link-external tm-rf3 tm-bold tm-lh-title"
-                rel="noreferrer noopener"
-                target="_blank"
-                >Chain Name Service</a
+                class="tm-link-external tm-rf3 tm-bold tm-lh-title"
+                >Chain Name Service</tm-link
               >
             </h3>
             <div class="desc tm-rf0 tm-lh-copy tm-measure">
@@ -388,12 +374,10 @@
           </div>
           <div class="mid">
             <h3 class="title">
-              <a
+              <tm-link
                 href="https://github.com/ChorusOne/liquid-staking"
-                class="tm-link tm-link-external tm-rf3 tm-bold tm-lh-title"
-                rel="noreferrer noopener"
-                target="_blank"
-                >Staking Derivatives</a
+                class="tm-link-external tm-rf3 tm-bold tm-lh-title"
+                >Staking Derivatives</tm-link
               >
             </h3>
             <div class="desc tm-rf0 tm-lh-copy tm-measure">

--- a/pages/learn/get-atom.vue
+++ b/pages/learn/get-atom.vue
@@ -320,7 +320,7 @@
               world, building the new era of the internet.
             </div>
             <div class="grid-wrapper">
-              <a
+              <tm-link
                 v-for="item in links"
                 :key="item.logo"
                 :href="item.url"
@@ -342,7 +342,7 @@
                     </div>
                   </div>
                 </div>
-              </a>
+              </tm-link>
             </div>
             <div class="footer">
               <tm-button
@@ -642,13 +642,14 @@ export default {
   display grid
   grid-template-columns repeat(auto-fit, minmax(24rem, 1fr))
   grid-gap 0 var(--grid-gap-x)
+  row-gap var(--spacing-9)
+  margin-top var(--spacing-9)
 
 .grid-item
   display grid
   grid-auto-flow column
   grid-template-columns min-content 1fr
   gap var(--spacing-7)
-  margin-top var(--spacing-9)
   border-radius $border-radius-5
   hover-raise(-2px)
 


### PR DESCRIPTION
We no longer need to write `<a href="" target="_blank" rel="noreferrer noopener" class="tm-link>` cc: @nassdonald 

I've handled below in our `tm-link` component.
```
default - <a href="">
external - <a href="" target="_blank" rel="noreferrer noopener">
internal - <nuxt-link to="/features">
anchor - <a href="" v-scroll-to="">
```

We just need to `<tm-link href="">` next time :) 

- tm-link rewrite
- reset h1 → h6 margins
- remove all the `.tm-link` in `<a>` except for `<nuxt-link>`'s and `<p>`'s `.tm-link`
- add external link icons `.tm-link-external` to primary nav

Closes https://github.com/cosmos/cosmos.network/issues/88 https://github.com/cosmos/cosmos.network/issues/74 https://github.com/cosmos/cosmos.network/issues/83
      
      